### PR TITLE
Ubuntu sal2 update docs

### DIFF
--- a/docs/Upgrading_on_Ubuntu_12.md
+++ b/docs/Upgrading_on_Ubuntu_12.md
@@ -43,7 +43,7 @@ INSTALLED_APPS = (
     'sal',
     'server',
     'south',
-     'bootstrap3',
+    'bootstrap3',
 )
 ```
 


### PR DESCRIPTION
Some minor changes to the Upgrading on Ubuntu 12.  Note these work and were tested on Ubuntu 14.04.1  Not sure how to differentiate things out between verions, but I don't think the OS version is much of an issue with these changes.
